### PR TITLE
feat: calculate & show estimated reading time

### DIFF
--- a/src/components/BlogPage/PostList/PostList.component.tsx
+++ b/src/components/BlogPage/PostList/PostList.component.tsx
@@ -1,4 +1,6 @@
-import type { PostWithoutContent } from '../../../types/post.types'
+import calculateReadingTime from '@/src/utils/calculateReadingTime.util'
+
+import type { Post } from '../../../types/post.types'
 
 import EmptyPostListComponent from './EmptyPostList.component'
 import PaginationComponent from './Pagination.component'
@@ -7,7 +9,7 @@ import SinglePostPreviewComponent from './SinglePostPreview.component'
 import styles from './PostList.component.module.scss'
 
 interface PostListComponentProps {
-  posts: PostWithoutContent[]
+  posts: Post[]
   currentPage: number
   maxPage: number
   generateLinkToPage: (pageNumber: number) => string
@@ -24,20 +26,25 @@ const PostListComponent: React.FC<PostListComponentProps> = ({
       {posts.length > 0 ? (
         <>
           <ul>
-            {posts.map((post) => (
-              <div key={`${post.slug}-div`}>
-                <SinglePostPreviewComponent
-                  key={post.slug}
-                  categories={post.categories}
-                  title={post.title}
-                  date={post.date}
-                  slug={post.slug}
-                  excerpt={post.excerpt}
-                />
+            {posts.map((post) => {
+              const readingTime = calculateReadingTime(post.content)
 
-                <hr className={styles.HorizontalRule} />
-              </div>
-            ))}
+              return (
+                <div key={`${post.slug}-div`}>
+                  <SinglePostPreviewComponent
+                    key={post.slug}
+                    categories={post.categories}
+                    title={post.title}
+                    date={post.date}
+                    slug={post.slug}
+                    excerpt={post.excerpt}
+                    readingTime={readingTime}
+                  />
+
+                  <hr className={styles.HorizontalRule} />
+                </div>
+              )
+            })}
           </ul>
 
           <PaginationComponent

--- a/src/components/BlogPage/PostList/SinglePostPreview.component.module.scss
+++ b/src/components/BlogPage/PostList/SinglePostPreview.component.module.scss
@@ -23,8 +23,19 @@
 
 .Header {
   display: flex;
+  flex-flow: column;
+}
+
+.CategoryAndDate {
+  display: flex;
   flex-flow: row;
   justify-content: space-between;
+}
+
+.ReadingTime {
+  display: flex;
+  justify-content: flex-end;
+  color: #6c6c6c;
 }
 
 .Category {

--- a/src/components/BlogPage/PostList/SinglePostPreview.component.tsx
+++ b/src/components/BlogPage/PostList/SinglePostPreview.component.tsx
@@ -6,7 +6,9 @@ import DateFormatterComponent from '../DateFormatter.component'
 
 import styles from './SinglePostPreview.component.module.scss'
 
-interface SinglePostPreviewComponentProps extends PostWithoutContent {}
+interface SinglePostPreviewComponentProps extends PostWithoutContent {
+  readingTime: number
+}
 
 const SinglePostPreviewComponent: React.FC<SinglePostPreviewComponentProps> = ({
   categories,
@@ -14,6 +16,7 @@ const SinglePostPreviewComponent: React.FC<SinglePostPreviewComponentProps> = ({
   date,
   excerpt,
   slug,
+  readingTime,
 }) => {
   const mainCategory = categories?.[0]
 
@@ -26,15 +29,19 @@ const SinglePostPreviewComponent: React.FC<SinglePostPreviewComponentProps> = ({
       </h1>
 
       <div className={styles.Header}>
-        <Link
-          className={styles.Category}
-          as={`/blog/category/${mainCategory}`}
-          href="/blog/category/[mainCategory]"
-        >
-          {mainCategory}
-        </Link>
+        <div className={styles.CategoryAndDate}>
+          <Link
+            className={styles.Category}
+            as={`/blog/category/${mainCategory}`}
+            href="/blog/category/[mainCategory]"
+          >
+            {mainCategory}
+          </Link>
 
-        <DateFormatterComponent dateString={date} />
+          <DateFormatterComponent dateString={date} />
+        </div>
+
+        <div className={styles.ReadingTime}>{readingTime} min read</div>
       </div>
 
       <p className={styles.Excerpt}>{excerpt}</p>

--- a/src/components/BlogPage/SinglePost/SinglePost.component.module.scss
+++ b/src/components/BlogPage/SinglePost/SinglePost.component.module.scss
@@ -31,6 +31,11 @@
 
 .Header {
   display: flex;
+  flex-flow: column;
+}
+
+.CategoryAndDate {
+  display: flex;
   flex-flow: row;
   justify-content: space-between;
 }
@@ -46,4 +51,10 @@
 
 .Excerpt {
   margin-top: 32px;
+}
+
+.ReadingTime {
+  display: flex;
+  justify-content: flex-end;
+  color: #6c6c6c;
 }

--- a/src/components/BlogPage/SinglePost/SinglePost.component.tsx
+++ b/src/components/BlogPage/SinglePost/SinglePost.component.tsx
@@ -1,4 +1,5 @@
 import type { Post, PostWithoutContent } from '@/src/types/post.types'
+import calculateReadingTime from '@/src/utils/calculateReadingTime.util'
 
 import DateFormatterComponent from '../DateFormatter.component'
 
@@ -19,15 +20,21 @@ const SinglePostComponent: React.FC<SinglePostComponentProps> = ({
   post,
   morePosts,
 }) => {
+  const readingTime = calculateReadingTime(post.content)
+
   return (
     <>
       <article>
         <h1 className={styles.Title}>{title}</h1>
 
         <div className={styles.Header}>
-          <span className={styles.Category}>{post.categories?.[0]}</span>
+          <div className={styles.CategoryAndDate}>
+            <span className={styles.Category}>{post.categories?.[0]}</span>
 
-          <DateFormatterComponent dateString={post.date} />
+            <DateFormatterComponent dateString={post.date} />
+          </div>
+
+          <div className={styles.ReadingTime}>{readingTime} min read</div>
         </div>
 
         <div className={styles.Excerpt}>{post.excerpt}</div>

--- a/src/pages/blog/category/[category]/[page].page.tsx
+++ b/src/pages/blog/category/[category]/[page].page.tsx
@@ -50,7 +50,15 @@ export const getStaticProps = async ({ params }: GetStaticPropsParams) => {
 
   const { posts, totalPosts } = await getPostsByCategory({
     category: params.category,
-    fields: ['categories', 'title', 'date', 'slug', 'excerpt', 'keywords'],
+    fields: [
+      'categories',
+      'title',
+      'date',
+      'slug',
+      'excerpt',
+      'keywords',
+      'content',
+    ],
     pageNumber,
     postsPerPage: POSTS_PER_PAGE,
   })

--- a/src/pages/blog/category/[category]/index.page.tsx
+++ b/src/pages/blog/category/[category]/index.page.tsx
@@ -33,7 +33,15 @@ interface GetStaticPropsParams {
 export const getStaticProps = async ({ params }: GetStaticPropsParams) => {
   const { posts, totalPosts } = await getPostsByCategory({
     category: params.category,
-    fields: ['categories', 'title', 'date', 'slug', 'excerpt', 'keywords'],
+    fields: [
+      'categories',
+      'title',
+      'date',
+      'slug',
+      'excerpt',
+      'keywords',
+      'content',
+    ],
     pageNumber: 1,
     postsPerPage: POSTS_PER_PAGE,
   })

--- a/src/pages/blog/index.page.tsx
+++ b/src/pages/blog/index.page.tsx
@@ -23,7 +23,15 @@ export const getStaticProps: GetStaticProps = async () => {
   await generateRssFeed()
 
   const { posts, totalPosts } = await getAllPostsPaginated({
-    fields: ['categories', 'title', 'date', 'slug', 'excerpt', 'keywords'],
+    fields: [
+      'categories',
+      'title',
+      'date',
+      'slug',
+      'excerpt',
+      'keywords',
+      'content',
+    ],
     pageNumber: 1,
     postsPerPage: POSTS_PER_PAGE,
   })

--- a/src/pages/blog/keyword/[keyword]/[page].page.tsx
+++ b/src/pages/blog/keyword/[keyword]/[page].page.tsx
@@ -50,7 +50,15 @@ export const getStaticProps = async ({ params }: GetStaticPropsParams) => {
 
   const { posts, totalPosts } = await getPostsByKeyword({
     keyword: params.keyword,
-    fields: ['categories', 'title', 'date', 'slug', 'excerpt', 'keywords'],
+    fields: [
+      'categories',
+      'title',
+      'date',
+      'slug',
+      'excerpt',
+      'keywords',
+      'content',
+    ],
     pageNumber,
     postsPerPage: POSTS_PER_PAGE,
   })

--- a/src/pages/blog/keyword/[keyword]/index.page.tsx
+++ b/src/pages/blog/keyword/[keyword]/index.page.tsx
@@ -33,7 +33,15 @@ interface GetStaticPropsParams {
 export const getStaticProps = async ({ params }: GetStaticPropsParams) => {
   const { posts, totalPosts } = await getPostsByKeyword({
     keyword: params.keyword,
-    fields: ['categories', 'title', 'date', 'slug', 'excerpt', 'keywords'],
+    fields: [
+      'categories',
+      'title',
+      'date',
+      'slug',
+      'excerpt',
+      'keywords',
+      'content',
+    ],
     pageNumber: 1,
     postsPerPage: POSTS_PER_PAGE,
   })

--- a/src/pages/blog/page/[page].page.tsx
+++ b/src/pages/blog/page/[page].page.tsx
@@ -49,7 +49,15 @@ export const getStaticProps = async ({ params }: GetStaticPropsParams) => {
   const pageNumber = parseInt(params.page)
 
   const { posts, totalPosts } = await getAllPostsPaginated({
-    fields: ['categories', 'title', 'date', 'slug', 'excerpt', 'keywords'],
+    fields: [
+      'categories',
+      'title',
+      'date',
+      'slug',
+      'excerpt',
+      'keywords',
+      'content',
+    ],
     pageNumber,
     postsPerPage: POSTS_PER_PAGE,
   })

--- a/src/utils/calculateReadingTime.util.ts
+++ b/src/utils/calculateReadingTime.util.ts
@@ -1,0 +1,31 @@
+// This is based on Pavel Polivka's implementation
+// https://ppolivka.com/posts/reading-time-stat-in-nextjs-blog
+
+// TODO
+// 1) Optimize ALPHANUMERIC_CHARS - generate a map based on the array
+// 2) Invoke it only once per post - has to be saved in .md or cached
+
+const ALPHANUMERIC_CHARS =
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
+
+const WORDS_PER_MINUTE = 225
+
+const isAlphanumeric = (char: string): boolean =>
+  ALPHANUMERIC_CHARS.includes(char)
+
+const isWord = (str: string): boolean =>
+  Array.from(str).some((char) => isAlphanumeric(char))
+
+const getWordCount = (input: string): number => {
+  const text = input.split(/\s+/)
+
+  return text.filter(isWord).length
+}
+
+const calculateReadingTime = (text: string) => {
+  const wordCount = getWordCount(text)
+
+  return Math.ceil(wordCount / WORDS_PER_MINUTE)
+}
+
+export default calculateReadingTime


### PR DESCRIPTION
## What was done

Added reading time calculator.

This is based on @PavlikPolivka implementation - https://ppolivka.com/posts/reading-time-stat-in-nextjs-blog

I made some code-style adjustments, made the function more readable as well.


## Further possible improvements

Two performance optimizations are possible:
1) significant - calculate reading time only one time per post (either save in .md or cache)
2) smaller - for `ALPHANUMERIC_CHARS` generate a map to speed up look up
