### PR TITLE
refactor: minor fixes in rootLayout and NavigationItem

### DIFF
--- a/app/rootLayout.component.tsx
+++ b/app/rootLayout.component.tsx
@@ -11,7 +11,7 @@ import useSmoothChangeThemeColorOnScroll from '@/src/hooks/useSmoothChangeThemeC
 import { ContextProviders } from './contextProviders'
 import { latoFont } from './fonts'
 
-import 'src/styles/globalStyles.scss'
+import '@/src/styles/globalStyles.scss'
 
 interface RootLayoutComponentProps {
   children: React.ReactNode

--- a/app/rootLayout.component.tsx
+++ b/app/rootLayout.component.tsx
@@ -7,7 +7,6 @@ import FullScreenNavigation from '@/src/components/Navigation/FullScreenNavigati
 import useBodyScrollLock from '@/src/hooks/useBodyScrollLock.hook'
 import useEffectInWindow from '@/src/hooks/useEffectInWindow.hook'
 import useSmoothChangeThemeColorOnScroll from '@/src/hooks/useSmoothChangeThemeColorOnScroll.hook'
-import globalStyleVariables from '@/src/styles/globalVariables.module.scss'
 
 import { ContextProviders } from './contextProviders'
 import { latoFont } from './fonts'
@@ -26,19 +25,12 @@ const RootLayoutComponent: React.FC<RootLayoutComponentProps> = ({
   const [isOpenFullScreenNavigation, setIsOpenFullScreenNavigation] =
     useState(false)
 
-  const dynamicThemeColor = useSmoothChangeThemeColorOnScroll()
-  const [themeColor, setThemeColor] = useState(
-    globalStyleVariables.backgroundColor,
-  )
-
-  useEffectInWindow(() => {
-    if (dynamicThemeColor) {
-      setThemeColor(dynamicThemeColor)
-    }
-  }, [dynamicThemeColor])
+  const themeColor = useSmoothChangeThemeColorOnScroll()
 
   const { lockScroll, unlockScroll } = useBodyScrollLock()
 
+  // Technically lockScroll & unlockScroll could've been outside useEffect
+  // But since this is a side-effect, I left it inside
   useEffectInWindow(() => {
     if (isOpenFullScreenNavigation) {
       lockScroll()

--- a/src/components/Navigation/NavigationItem.component.tsx
+++ b/src/components/Navigation/NavigationItem.component.tsx
@@ -39,8 +39,10 @@ const NavigationItemComponent: React.FC<NavigationItemComponentProps> = ({
   const buttonStyles = classNames({
     [styles.Button]: location !== 'header-name',
     [latoFont.className]: location !== 'header-name',
+
     [styles.Button_NoStyle]: location === 'header-name',
     [robotoMonoFont.className]: location === 'header-name',
+
     [styles.Button_FullScreen]: location === 'full-screen',
     [styles.Active]: isHighlightable,
   })


### PR DESCRIPTION
## What was done

A couple of changes in `rootLayout`, mainly to `useEffect` and setting state derived from other state. Also a small change in `NavigationItem` for easier readability.