### PR TITLE
fix(lato font): fix rendering issues on large screens

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,10 +1,14 @@
-import { Lato, Roboto, Roboto_Mono } from 'next/font/google'
+import { Roboto, Roboto_Mono } from 'next/font/google'
 
-export const latoFont = Lato({
-  weight: ['400', '900'],
-  subsets: ['latin'],
-  display: 'swap',
-})
+// Lato font breaks rendering on large screens, when imported via Next fonts
+// So instead, we're importing it from Google Fonts CDN in CSS directly
+export const latoFont = { className: 'latoFont' }
+
+// export const latoFont = Lato({
+//   weight: ['400', '900'],
+//   subsets: ['latin'],
+//   display: 'swap',
+// })
 
 export const robotoFont = Roboto({
   weight: ['100'],

--- a/src/styles/globalStyles.scss
+++ b/src/styles/globalStyles.scss
@@ -1,5 +1,6 @@
 @import './globalVariables.module.scss';
 @import './globalMixins.scss';
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap');
 
 html,
 body,
@@ -69,4 +70,8 @@ div#root-layout {
 
 ::-webkit-scrollbar-thumb {
   background-color: #ff4248;
+}
+
+.latoFont {
+  font-family: 'Lato', sans-serif;
 }


### PR DESCRIPTION
## What was done

Lato font breaks rendering on large screens when imported via Next fonts. This fixes it by importing Lato font from Google Fonts CDN directly in CSS. This has implications for the font not being colocated on our servers, but the performance hit is negligible.

Before:
![font](https://github.com/szymonpulut/szymonpulut.github.io/assets/1353480/9f84d3d3-a6e0-4fd8-9972-9df1cc224de7)

After:
![image](https://github.com/szymonpulut/szymonpulut.github.io/assets/1353480/0a492bbf-0333-4b5b-90fa-a2ba321ed505)

