### PR TITLE
fix: font optimization

### DIFF
--- a/app/fonts.ts
+++ b/app/fonts.ts
@@ -1,14 +1,10 @@
-import { Roboto, Roboto_Mono } from 'next/font/google'
+import { Lato, Roboto, Roboto_Mono } from 'next/font/google'
 
-// Lato font breaks rendering on large screens, when imported via Next fonts
-// So instead, we're importing it from Google Fonts CDN in CSS directly
-export const latoFont = { className: 'latoFont' }
-
-// export const latoFont = Lato({
-//   weight: ['400', '900'],
-//   subsets: ['latin'],
-//   display: 'swap',
-// })
+export const latoFont = Lato({
+  weight: ['400', '900'],
+  subsets: ['latin'],
+  display: 'swap',
+})
 
 export const robotoFont = Roboto({
   weight: ['100'],

--- a/app/rootLayout.component.tsx
+++ b/app/rootLayout.component.tsx
@@ -49,18 +49,6 @@ const RootLayoutComponent: React.FC<RootLayoutComponentProps> = ({
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link
-          rel="preconnect"
-          href="https://fonts.gstatic.com"
-          crossOrigin="anonymous"
-        />
-        {/* eslint-disable-next-line @next/next/no-page-custom-font */}
-        <link
-          href="https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap"
-          rel="stylesheet"
-        />
-
         <link rel="icon" type="image/x-icon" href="/icon.svg" />
 
         <link

--- a/next.config.js
+++ b/next.config.js
@@ -2,6 +2,7 @@
 
 const nextConfig = {
   output: 'export',
+  optimizeFonts: false,
   pageExtensions: ['page.tsx', 'page.ts', 'page.jsx', 'page.js'],
 }
 

--- a/src/styles/globalStyles.scss
+++ b/src/styles/globalStyles.scss
@@ -1,5 +1,6 @@
 @import './globalVariables.module.scss';
 @import './globalMixins.scss';
+@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap');
 
 html,
 body,

--- a/src/styles/globalStyles.scss
+++ b/src/styles/globalStyles.scss
@@ -1,6 +1,5 @@
 @import './globalVariables.module.scss';
 @import './globalMixins.scss';
-@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap');
 
 html,
 body,
@@ -70,8 +69,4 @@ div#root-layout {
 
 ::-webkit-scrollbar-thumb {
   background-color: #ff4248;
-}
-
-.latoFont {
-  font-family: 'Lato', sans-serif;
 }


### PR DESCRIPTION
## What was done

Finally found the cause for weird font rendering: https://github.com/vercel/next.js/issues/24640

Previous attempts (reverted):
https://github.com/szymonpulut/szymonpulut.github.io/pull/76
https://github.com/szymonpulut/szymonpulut.github.io/pull/70

Before:
![font](https://github.com/szymonpulut/szymonpulut.github.io/assets/1353480/9f84d3d3-a6e0-4fd8-9972-9df1cc224de7)

After:
![image](https://github.com/szymonpulut/szymonpulut.github.io/assets/1353480/0a492bbf-0333-4b5b-90fa-a2ba321ed505)