### PR TITLE
fix(lato font): move lato font fetching to root layout component

### DIFF
--- a/app/rootLayout.component.tsx
+++ b/app/rootLayout.component.tsx
@@ -49,6 +49,18 @@ const RootLayoutComponent: React.FC<RootLayoutComponentProps> = ({
         <meta charSet="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
 
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        {/* eslint-disable-next-line @next/next/no-page-custom-font */}
+        <link
+          href="https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap"
+          rel="stylesheet"
+        />
+
         <link rel="icon" type="image/x-icon" href="/icon.svg" />
 
         <link

--- a/src/styles/globalStyles.scss
+++ b/src/styles/globalStyles.scss
@@ -1,6 +1,5 @@
 @import './globalVariables.module.scss';
 @import './globalMixins.scss';
-@import url('https://fonts.googleapis.com/css2?family=Lato:wght@400;900&display=swap');
 
 html,
 body,


### PR DESCRIPTION
## What was done

This ends the battle of using `Lato` font in Next. It isn't documented at all, but some things don't work when building while they work locally.

Follow up to: https://github.com/szymonpulut/szymonpulut.github.io/pull/79